### PR TITLE
Command line result must split on new lines.

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -14,7 +14,7 @@ exports.init = function (grunt) {
       return;
     }
 
-    results = results.split("\n");
+    //results = results.split("\n");
     xml = xmlBuilder.create('testsuites');
 
     xml.ele('testsuite', {
@@ -90,10 +90,16 @@ exports.init = function (grunt) {
       }
 
       writeReport(options['reporterOutput'], results);
-      grunt.log.writeln(results);
+      //grunt.log.writeln(results);
 
       done(results);
     });
+    
+    child.stdout.on('write', function (out) {
+      grunt.log.writeln(out);
+    });
+
+
   };
 
   return exports;


### PR DESCRIPTION
The addition of this line prevents the code from failing on my end. I'm not sure why it was removed in https://github.com/ahmednuaman/grunt-scss-lint/commit/30cfe1965c15ac12547ac061cc7515679ddb677c#diff-645234eaf132f71efcced1a734ebb8f6
