### PR TITLE
Fix error check and printing of nonsense

### DIFF
--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -19,14 +19,12 @@ module.exports = function (grunt) {
     grunt.log.writeln('Running scss-lint on ' + target);
 
     scsslint.lint(files, opts, function (results) {
-      var success = results[0] === '';
+      var success = _.isEmpty(results);
 
       if (success) {
         grunt.log.oklns(fileCount + ' files are lint free');
       } else {
-        _.forEach(results, function(result) {
-          grunt.log.writeln(result);
-        });
+        grunt.log.writeln(result);
       }
 
       if (opts.reporterOutput) {


### PR DESCRIPTION
This fixes the error check that happens on line 22 as well as fixes the nonsense that happens at line 26. 

We have been getting failures even when our SASS files are valid because `results` is an empty string when  a success happens and `results[0]` yields `undefined`, thus `var success = results[0] === ''` equals false.

Also, `result` is a string so by looping through the result string and printing out each character results in... https://gist.github.com/alexfu/9627472.
