### PR TITLE
Disable logging from imported lint lib.

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -87,7 +87,6 @@ exports.init = function (grunt) {
       }
 
       writeReport(options['reporterOutput'], results);
-      grunt.log.writeln(results);
 
       done(results);
     });


### PR DESCRIPTION
This was causing a double output of the results when grunt invoked scss-lint.
