### PR TITLE
Fix typo in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ grunt.initConfig({
       'test/fixtures/*.scss',
     ],
     options: {
-      bundler: true,
+      bundleExec: true,
       config: '.scss-lint.yml',
       reporterOutput: 'scss-lint-report.xml'
     },


### PR DESCRIPTION
![ ](http://media.giphy.com/media/rPf5Sjkzx8pvG/giphy.gif)
