### PR TITLE
Add compact output for CLI

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,8 @@ module.exports = function (grunt) {
         config: '.scss-lint.yml',
         reporterOutput: 'scss-lint-report.xml',
         bundleExec: false,
-        colorizeOutput: true
+        colorizeOutput: true,
+        compact: true
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ You can choose to have your gems installed via [bundler](http://bundler.io) and 
 
 Get some nice looking output.
 
+#### compact
+
+- Type: `Boolean`
+- Default: `false`
+
+Group related linted files for more easier error review. XML output will still be default from scss-lint.
+
 #### config
 
 - Type: `String`

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -13,7 +13,8 @@ module.exports = function (grunt) {
       config: '.scss-lint.yml',
       reporterOutput: null,
       bundleExec: false,
-      colorizeOutput: true
+      colorizeOutput: true,
+      compact: false
     });
 
     grunt.verbose.writeflags(opts, 'scss-lint options');

--- a/test/fixtures/fail2.scss
+++ b/test/fixtures/fail2.scss
@@ -1,0 +1,4 @@
+.large-icon {
+	color:red;
+	@extend %icon;
+}


### PR DESCRIPTION
Easier display of errors inside command line interface. XML output will remain the same.
I hope that test cases are good enough to cover this change.

Before:
![screen shot 2014-06-01 at 12 26 04](https://cloud.githubusercontent.com/assets/389286/3141874/1cb9516c-e99d-11e3-9d54-3851eefd6104.png)

After:
![screen shot 2014-06-01 at 12 41 45](https://cloud.githubusercontent.com/assets/389286/3141875/22e7177c-e99d-11e3-83e5-44980f328d0e.png)
