### PR TITLE
scss-lint 0.7.0 does not work with this grunt task

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -59,7 +59,7 @@ exports.init = function (grunt) {
 
       var output = {},
       fileName = '',
-      matchesRe = /^(.+?\.scss)\:(\d+?)\s(\[\w+?\])\s(.+)/,
+      matchesRe = /^(.+?\.scss)\:(\d+?)\s\-\s(.+)/,
       matches;
       results = chalk.stripColor(results);
       results = (results.length !== 0) ? results.split("\n") : [];
@@ -79,8 +79,7 @@ exports.init = function (grunt) {
 
         output[fileName].push({
           line: matches[2],
-          type: matches[3],
-          description: matches[4]
+          description: matches[3]
         });
 
       });


### PR DESCRIPTION
As of scss-lint 0.7.0 lint errors return err.code == 1, this broke the grunt task. I have updated the code to look for err.code 1.  
