### PR TITLE
Update readme for grunt-newer friendly syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ The jUnit XML file to save the output to. If you don't want this then set the op
 ```javascript
 grunt.initConfig({
   scsslint: {
-    allFiles: [
-      'test/fixtures/*.scss',
-    ],
+    allFiles: {
+      src: [
+        'test/fixtures/*.scss',
+      ]
+    },
     options: {
       bundleExec: true,
       config: '.scss-lint.yml',


### PR DESCRIPTION
I think this is the favored way to provide files to fileSrc- and the best part is that it makes this plugin work nicely with (grunt-newer)https://github.com/tschaub/grunt-newer so you don't have to lint your entire sass dir every time. Went from ~20s/task to ~2s.
