### PR TITLE
Creating a verbose list of changes for the newest versions. Fixes #50.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,23 +1,29 @@
+For details, see link to the release page for each release.
+
+v0.1.12:
+  date: 2014-06-25
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.12:
+    - Integration with Grunt event
 v0.1.11:
   date: 2014-06-02
-  changes:
-    - https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.11
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.11:
+    - Fixed windows support of compact output
 v0.1.10:
   date: 2014-06-02
-  changes:
-    - https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.10
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.10:
+    - Added compact output
 v0.1.9:
   date: 2014-05-20
-  changes:
-    - https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.9
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.9:
+    - Updated gem to 0.24.0
 v0.1.8:
   date: 2014-05-20
-  changes:
-    - https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.8
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.8:
+    - Proper grammar
 v0.1.7:
   date: 2014-05-01
-  changes:
-    - https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.7
+  changes, https://github.com/ahmednuaman/grunt-scss-lint/releases/tag/v0.1.7:
+    - We can has colour!
 v0.1.6:
   date: 2014-04-26
   changes:


### PR DESCRIPTION
Also adding the latest version which was missing (v0.1.12).

Kept the links since they contain more information than the titles.

Example CHANGELOG file from the Grunt project:
https://github.com/gruntjs/grunt/blob/master/CHANGELOG
