### PR TITLE
Add compatability to latest scss-lint version 0.26.0

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -155,7 +155,7 @@ exports.init = function (grunt) {
       var message,
       rawResults;
 
-      if (err && err.code !== 65) {
+      if (err && err.code !== 1 && err.code !== 2 && err.code !== 65) {
         if (err.code === 127) {
           grunt.log.errorlns('1. Please make sure you have ruby installed: `ruby -v`');
           grunt.log.errorlns('2. Install the `scss-lint` gem by running:');


### PR DESCRIPTION
New error codes were introduced in scss-lint version 0.26.0. This adds them in the error handling.

Cheers
