### PR TITLE
Properly colorize compact results

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -117,7 +117,7 @@ exports.init = function (grunt) {
 
       _.forEach(results, function (result, index, collection) {
         str += '\n';
-        str += chalk.bold(index);
+        str += chalk.cyan.bold(index);
         str += '\n';
         str += iterateErrors(result);
       });

--- a/test/scss-lint-test.js
+++ b/test/scss-lint-test.js
@@ -299,7 +299,7 @@ exports.scsslint = {
       results = results.split('\n');
 
       test.ok(
-        results[1].indexOf(styles.bold.open + file1) !== -1,
+        results[1].indexOf(styles.cyan.open + file1) !== -1,
         'Should report file name of first file.'
       );
 
@@ -314,7 +314,7 @@ exports.scsslint = {
       );
 
       test.ok(
-        results[7].indexOf(styles.bold.open + file2) !== -1,
+        results[7].indexOf(styles.cyan.open + file2) !== -1,
         'Should report file name of second file.'
       );
 


### PR DESCRIPTION
Compact results aren't colorized the same as non-compact. These changes introduce the same colorization non-compact results have to compact results.
