### PR TITLE
Do not attempt to run linter when there are 0 input files.

### DIFF
--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -24,6 +24,13 @@ module.exports = function (grunt) {
 
     grunt.log.writeln('Running scss-lint on ' + target);
 
+    // Do nothing if there are no files to lint.
+    if (!files.length) {
+        grunt.log.error('0 files linted. Please check your ignored files.');
+        done();
+        return;
+    }
+
     scsslint.lint(files, opts, function (results) {
       if (results === false) {
         done(false);


### PR DESCRIPTION
Check for 0 files before running the linter.

closes ahmednuaman/grunt-scss-lint#79
