### PR TITLE
adds option to have bundleExec be ran in a different directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Exclude one or more files from being linted.
 
 The jUnit XML file to save the output to. If you don't want this then set the option as `null`.
 
+#### format
+
+- Type: `String`
+- Default: `Default`
+
+The Output Format you'd like to see, like JSON. Options are listed on [scss-lint/formatters](https://github.com/causes/scss-lint#formatters).
+
 #### emitError
 - Type: `Boolean`
 - Default: `false`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The jUnit XML file to save the output to. If you don't want this then set the op
 
 The Output Format you'd like to see, like JSON. Options are listed on [scss-lint/formatters](https://github.com/causes/scss-lint#formatters).
 
+#### out
+
+- Type: `String`
+- Default: `STDOUT`
+
+Where to write the output to, you can pick any path for a file output, or leave the default to just show it in the Terminal output (STDOUT). Basically adds `--out {your value}` as documented at [scss-lint](https://github.com/causes/scss-lint). Can be combined with `format` above to output a formatted file to a location.
+
 #### emitError
 - Type: `Boolean`
 - Default: `false`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The Output Format you'd like to see, like JSON. Options are listed on [scss-lint
 #### out
 
 - Type: `String`
-- Default: `STDOUT`
+- Default: `null`
 
 Where to write the output to, you can pick any path for a file output, or leave the default to just show it in the Terminal output (STDOUT). Basically adds `--out {your value}` as documented at [scss-lint](https://github.com/causes/scss-lint). Can be combined with `format` above to output a formatted file to a location.
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ This task requires you to have [Ruby](http://www.ruby-lang.org/en/downloads/), a
 
 #### bundleExec
 
-- Type: `Boolean`
+- Type: `Boolean` or `String`
 - Default: `false`
 
-You can choose to have your gems installed via [bundler](http://bundler.io) and if so, set this option to `true` to use the local gems.
+You can choose to have your gems installed via [bundler](http://bundler.io) and if so, set this option to `true` to use the local gems. This will require that your `Gemfile` is in the same directory as your `Gruntfile.js`; if that is not the case, use a string that is the path to the directory where `Gemfile` is - the same place commands like `bundle exec scss-lint` should be ran from.
 
 #### colorizeOutput
 

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -141,21 +141,24 @@ exports.init = function (grunt) {
     } else if (options.bundleExec) {
       // path string given to location of 'Gemfile'
       args.push('cd ' + options.bundleExec.trim() + ' && bundle exec scss-lint');
+      
       config = path.relative(options.bundleExec, config);
       exclude = grunt.file.expand(exclude);
+      
       var newExclude = [];
       exclude.forEach(function(item) {
-        "use strict";
         newExclude.push(path.relative(options.bundleExec, item));
       });
       exclude = newExclude;
+      
       var newFiles = [];
       files.forEach(function(file) {
-        "use strict";
         newFiles.push(path.relative(options.bundleExec, file));
       });
       files = newFiles;
-      // console.log(files);
+      
+      options.out = path.relative(options.bundleExec, options.out);
+      
     } else {
       args.push('scss-lint');
     }
@@ -171,6 +174,12 @@ exports.init = function (grunt) {
       options.compact = false;
     }
 
+    if (options.out !== 'STDOUT') {
+      args.push('--out ' + options.out.trim());
+      options.colorizeOutput = false;
+      options.compact = false;
+    }
+    
     if (exclude) {
       args.push('-e');
       //args.push(grunt.file.expand(exclude).join(','));

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -101,13 +101,13 @@ exports.init = function (grunt) {
                         chalk.magenta(error.line) + ': ' + 
                         chalk.yellow(error.type) + ' ' + 
                         chalk.green(error.description[0]) + ': ' + 
-                        error.description[1] + '\n';
+                        _.rest(error.description) + '\n';
           } else {
             errorMsg += '  ' + 
                         chalk.magenta(error.line) + ': ' + 
                         chalk.red(error.type) + ' ' + 
-                        chalk.green(error.description[0]) + ': ' + 
-                        error.description[1] + '\n';
+                        chalk.green(error.description[0]) + ': ' +
+                        _.rest(error.description) + '\n';
           }
         });
 

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -168,13 +168,15 @@ exports.init = function (grunt) {
       if (out !== null) {
         out = path.relative(options.bundleExec, out);
       }
-      exclude = grunt.file.expand(exclude);
       
-      var newExclude = [];
-      exclude.forEach(function (item) {
-        newExclude.push(path.relative(options.bundleExec, item));
-      });
-      exclude = newExclude;
+      if (exclude) {
+        exclude = grunt.file.expand(exclude);
+        var newExclude = [];
+        exclude.forEach(function (item) {
+          newExclude.push(path.relative(options.bundleExec, item));
+        });
+        exclude = newExclude;
+      }
       
       var newFiles = [];
       files.forEach(function (file) {
@@ -202,7 +204,6 @@ exports.init = function (grunt) {
       options.colorizeOutput = false;
       options.compact = false;
     }
-    
     if (exclude) {
       args.push('-e');
       args.push(exclude.join(','));

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -5,6 +5,7 @@ exports.init = function (grunt) {
       xmlBuilder = require('xmlbuilder'),
       chalk = require('chalk'),
       path = require('path'),
+      fs = require('fs'),
       writeReport;
 
   writeReport = function (output, results) {
@@ -61,7 +62,7 @@ exports.init = function (grunt) {
           fileName = '',
           matchesRe = /^(.+?\.scss)\:(\d+?)\s(\[\w+?\])\s(.+)/,
           matches;
-
+      
       results = chalk.stripColor(results);
       results = results.length !== 0 ? results.split('\n') : [];
 
@@ -80,6 +81,7 @@ exports.init = function (grunt) {
 
           output[fileName].push({
             line: matches[2],
+            fileName: fileName,
             type: matches[3],
             description: matches[4].split(':')
           });
@@ -88,7 +90,7 @@ exports.init = function (grunt) {
 
       return output;
     },
-    output: function (results) {
+    output: function (results, options) {
       var str = '',
           iterateErrors;
 
@@ -108,6 +110,25 @@ exports.init = function (grunt) {
                         chalk.red(error.type) + ' ' + 
                         chalk.green(error.description[0]) + ': ' +
                         _.rest(error.description) + '\n';
+          }
+          //var file = path.relative(process.cwd(), path.resolve(error.fileName));
+          if (options.showCode) {
+            var file;
+            if (options.bundleExec) {
+              file = path.resolve(options.bundleExec, error.fileName);
+            } else {
+              file = error.fileName;
+            }
+            var contents = fs.readFileSync(file, "utf8");
+            var code = contents.split('\n');
+            errorMsg += '  ' +
+              code[(error.line - 3)] + '\n' +
+              code[(error.line - 2)] + '\n' +
+              chalk.bold(code[(error.line - 1)]) + '\n' +
+              code[(error.line)] + '\n' +
+              code[(error.line + 1)] + '\n' +
+              code[(error.line + 2)] + '\n' +
+              '\n' + '\n';
           }
         });
 
@@ -217,7 +238,7 @@ exports.init = function (grunt) {
       rawResults = results;
 
       if (results && options.compact) {
-        results = compact.output(results);
+        results = compact.output(results, options);
         if (!options.colorizeOutput) {
           results = chalk.stripColor(results);
         }

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -157,8 +157,6 @@ exports.init = function (grunt) {
       });
       files = newFiles;
       
-      options.out = path.relative(options.bundleExec, options.out);
-      
     } else {
       args.push('scss-lint');
     }
@@ -174,7 +172,7 @@ exports.init = function (grunt) {
       options.compact = false;
     }
 
-    if (options.out !== 'STDOUT') {
+    if (options.out) {
       args.push('--out ' + options.out.trim());
       options.colorizeOutput = false;
       options.compact = false;

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -146,13 +146,13 @@ exports.init = function (grunt) {
       exclude = grunt.file.expand(exclude);
       
       var newExclude = [];
-      exclude.forEach(function(item) {
+      exclude.forEach(function (item) {
         newExclude.push(path.relative(options.bundleExec, item));
       });
       exclude = newExclude;
       
       var newFiles = [];
-      files.forEach(function(file) {
+      files.forEach(function (file) {
         newFiles.push(path.relative(options.bundleExec, file));
       });
       files = newFiles;
@@ -182,7 +182,6 @@ exports.init = function (grunt) {
     
     if (exclude) {
       args.push('-e');
-      //args.push(grunt.file.expand(exclude).join(','));
       args.push(exclude.join(','));
     }
 

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -165,11 +165,9 @@ exports.init = function (grunt) {
       args.push('cd ' + options.bundleExec.trim() + ' && bundle exec scss-lint');
       
       config = path.relative(options.bundleExec, config);
-      console.log("OUT: ", out);
       if (out !== null) {
         out = path.relative(options.bundleExec, out);
       }
-      console.log("OUT: ", out);
       exclude = grunt.file.expand(exclude);
       
       var newExclude = [];

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -151,6 +151,7 @@ exports.init = function (grunt) {
   exports.lint = function (files, options, done) {
     var args = [],
         config = options['config'],
+        out = options['out'],
         exclude = options['exclude'],
         exec = require('child_process').exec,
         env = process.env,
@@ -164,6 +165,11 @@ exports.init = function (grunt) {
       args.push('cd ' + options.bundleExec.trim() + ' && bundle exec scss-lint');
       
       config = path.relative(options.bundleExec, config);
+      console.log("OUT: ", out);
+      if (out !== null) {
+        out = path.relative(options.bundleExec, out);
+      }
+      console.log("OUT: ", out);
       exclude = grunt.file.expand(exclude);
       
       var newExclude = [];
@@ -192,9 +198,9 @@ exports.init = function (grunt) {
       options.colorizeOutput = false;
       options.compact = false;
     }
-
-    if (options.out) {
-      args.push('--out ' + options.out.trim());
+    
+    if (out) {
+      args.push('--out ' + '"' + out.trim() + '"');
       options.colorizeOutput = false;
       options.compact = false;
     }

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -4,6 +4,7 @@ exports.init = function (grunt) {
       compact = {},
       xmlBuilder = require('xmlbuilder'),
       chalk = require('chalk'),
+      path = require('path'),
       writeReport;
 
   writeReport = function (output, results) {
@@ -134,21 +135,40 @@ exports.init = function (grunt) {
         env = process.env,
         fileCount = Array.isArray(files) ? files.length : 1,
         child;
-
-    args.push('scss-lint');
-
-    if (options.bundleExec) {
-      args.unshift('bundle', 'exec');
+    
+    if (options.bundleExec === true) {
+      args.push('bundle exec scss-lint');
+    } else if (options.bundleExec) {
+      // path string given to location of 'Gemfile'
+      args.push('cd ' + options.bundleExec.trim() + ' && bundle exec scss-lint');
+      config = path.relative(options.bundleExec, config);
+      exclude = grunt.file.expand(exclude);
+      var newExclude = [];
+      exclude.forEach(function(item) {
+        "use strict";
+        newExclude.push(path.relative(options.bundleExec, item));
+      });
+      exclude = newExclude;
+      var newFiles = [];
+      files.forEach(function(file) {
+        "use strict";
+        newFiles.push(path.relative(options.bundleExec, file));
+      });
+      files = newFiles;
+      //console.log(files);
+    } else {
+      args.push('scss-lint');
     }
 
     if (config) {
       args.push('-c');
-      args.push(config);
+      args.push('"' + config + '"');
     }
 
     if (exclude) {
       args.push('-e');
-      args.push(grunt.file.expand(exclude).join(','));
+      //args.push(grunt.file.expand(exclude).join(','));
+      args.push(exclude.join(','));
     }
 
     if (options.colorizeOutput) {

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -164,6 +164,12 @@ exports.init = function (grunt) {
       args.push('-c');
       args.push('"' + config + '"');
     }
+    
+    if (options.format !== 'Default') {
+      args.push('--format ' + options.format.trim());
+      options.colorizeOutput = false;
+      options.compact = false;
+    }
 
     if (exclude) {
       args.push('-e');
@@ -225,7 +231,7 @@ exports.init = function (grunt) {
           grunt.log.writeln('scss-lint failed, but was run in force mode');
         }
       }
-
+      
       if (options.reporterOutput) {
         writeReport(options.reporterOutput, grunt.log.uncolor(rawResults));
         grunt.log.writeln('Results have been written to: ' + options.reporterOutput);

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -155,7 +155,7 @@ exports.init = function (grunt) {
         newFiles.push(path.relative(options.bundleExec, file));
       });
       files = newFiles;
-      //console.log(files);
+      // console.log(files);
     } else {
       args.push('scss-lint');
     }
@@ -182,7 +182,6 @@ exports.init = function (grunt) {
     }
 
     args = args.concat(files);
-
     if (grunt.option('debug') !== undefined) {
       grunt.log.debug('Run command: ' + args.join(' '));
     }

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
       config: '.scss-lint.yml',
       reporterOutput: null,
       format: 'Default',
-      out: 'STDOUT',
+      out: null,
       bundleExec: false,
       colorizeOutput: true,
       compact: false,

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
     opts = this.options({
       config: '.scss-lint.yml',
       reporterOutput: null,
+      format: null,
       bundleExec: false,
       colorizeOutput: true,
       compact: false,

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -14,6 +14,7 @@ module.exports = function (grunt) {
       config: '.scss-lint.yml',
       reporterOutput: null,
       format: 'Default',
+      out: 'STDOUT',
       bundleExec: false,
       colorizeOutput: true,
       compact: false,

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
     opts = this.options({
       config: '.scss-lint.yml',
       reporterOutput: null,
-      format: null,
+      format: 'Default',
       bundleExec: false,
       colorizeOutput: true,
       compact: false,

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -18,6 +18,7 @@ module.exports = function (grunt) {
       bundleExec: false,
       colorizeOutput: true,
       compact: false,
+      showCode: false,
       force: false,
       maxBuffer: 300 * 1024
     });


### PR DESCRIPTION
Currently, you have to have `Gemfile` and `Gruntfile.js` in the same directory for the `bundleExec` option to work. This fixes that. Mind pulling it in?