### PR TITLE
add `gemVersion` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ This task requires you to have [Ruby](http://www.ruby-lang.org/en/downloads/), a
 
 You can choose to have your gems installed via [bundler](http://bundler.io) and if so, set this option to `true` to use the local gems.
 
+#### gemVersion
+
+- Type: `String`
+- Default: `null`
+
+Select a particular version of the scss-lint Ruby gem at the task level.
+
 #### colorizeOutput
 
 - Type: `Boolean`

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -141,6 +141,10 @@ exports.init = function (grunt) {
       args.unshift('bundle', 'exec');
     }
 
+    if (options.gemVersion) {
+      args.push('"_' + options.gemVersion + '_"');
+    }
+
     if (config) {
       args.push('-c');
       args.push(config);

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
     opts = this.options({
       config: 'node_modules/grunt-scss-lint/.scss-lint.yml',
       reporterOutput: null,
+      gemVersion: null,
       bundleExec: false,
       colorizeOutput: true,
       compact: false,

--- a/test/scss-lint-test.js
+++ b/test/scss-lint-test.js
@@ -134,6 +134,38 @@ exports.scsslint = {
     });
   },
 
+  gemVersion: function (test) {
+    test.expect(1);
+    var files = path.join(fixtures, 'pass.scss'),
+        muted = grunt.log.muted,
+        stdoutMsg = '',
+        testOptions;
+
+    grunt.log.muted = false;
+
+    testOptions = _.assign({}, defaultOptions, {
+      gemVersion: 'test_version'
+    });
+
+    grunt.option('debug', true);
+
+    hooker.hook(process.stdout, 'write', {
+      pre: function (result) {
+        stdoutMsg += grunt.log.uncolor(result);
+        return hooker.preempt();
+      }
+    });
+
+    scsslint.lint(files, testOptions, function (results) {
+      grunt.option('debug', undefined);
+      hooker.unhook(process.stdout, 'write');
+      grunt.log.muted = muted;
+
+      test.ok(stdoutMsg.indexOf('Run command: scss-lint \"_test_version_\" -c') !== -1, 'Apply gem version hint');
+      test.done();
+    });
+  },
+
   passWithExcludedFile: function (test) {
     test.expect(1);
     var files = path.join(fixtures, '*.scss'),


### PR DESCRIPTION
Allows specifying a particular version of the Ruby scss-lint gem at the task level.

I have an arcane need to deal with multiple versions of scss-lint within the same grunt run.

#### Changes

- Add `gemVersion` options making use of the Ruby gem version parameter (http://stackoverflow.com/questions/4061596/how-can-i-call-an-older-version-of-a-gem-from-the-commandline)
- Add unit test
- Update README.md