### PR TITLE
Upgrade to xmlbuilder 2.5.1 (req. for nodejs 0.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "lodash": "2.4.1",
-    "xmlbuilder": "2.4.3",
+    "xmlbuilder": "2.5.1",
     "chalk": "0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise npm install on nodejs 0.12 will fail with a warning, stating that xmlbuilder requires nodejs 0.8 ... 0.11.
```
npm WARN engine xmlbuilder@2.4.3: wanted: {"node":"0.8.x || 0.10.x || 0.11.x"} (current: {"node":"0.12.0","npm":"2.5.1"})
```