### PR TITLE
Improve console output

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -98,13 +98,13 @@ exports.init = function (grunt) {
         _.forEach(errors, function (error) {
           if (error.type === '[W]') {
             errorMsg += '  ' +
-                        chalk.magenta(error.line) + ': ' +
+                        chalk.magenta(error.line) + ':\t' +
                         chalk.yellow(error.type) + ' ' +
                         chalk.green(error.description[0]) + ': ' +
                         error.description[1] + '\n';
           } else {
             errorMsg += '  ' +
-                        chalk.magenta(error.line) + ': ' +
+                        chalk.magenta(error.line) + ':\t' +
                         chalk.red(error.type) + ' ' +
                         chalk.green(error.description[0]) + ': ' +
                         error.description[1] + '\n';

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -101,14 +101,14 @@ exports.init = function (grunt) {
           if (error.type === '[W]') {
             warningCount += 1;
             errorMsg += '  ' +
-                        chalk.magenta(error.line) + ':\t' +
+                        chalk.magenta(error.line) + ': ' +
                         chalk.yellow(error.type) + ' ' +
                         chalk.green(error.description[0]) + ': ' +
                         error.description[1] + '\n';
           } else {
             errorCount += 1;
             errorMsg += '  ' +
-                        chalk.magenta(error.line) + ':\t' +
+                        chalk.magenta(error.line) + ': ' +
                         chalk.red(error.type) + ' ' +
                         chalk.green(error.description[0]) + ': ' +
                         error.description[1] + '\n';

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -90,19 +90,23 @@ exports.init = function (grunt) {
     },
     output: function (results) {
       var str = '',
-          iterateErrors;
+          iterateErrors,
+          warningCount = 0,
+          errorCount = 0;
 
       iterateErrors = function (errors) {
         var errorMsg = '';
 
         _.forEach(errors, function (error) {
           if (error.type === '[W]') {
+            warningCount += 1;
             errorMsg += '  ' +
                         chalk.magenta(error.line) + ':\t' +
                         chalk.yellow(error.type) + ' ' +
                         chalk.green(error.description[0]) + ': ' +
                         error.description[1] + '\n';
           } else {
+            errorCount += 1;
             errorMsg += '  ' +
                         chalk.magenta(error.line) + ':\t' +
                         chalk.red(error.type) + ' ' +
@@ -122,6 +126,17 @@ exports.init = function (grunt) {
         str += '\n';
         str += iterateErrors(result);
       });
+
+      if (errorCount || warningCount) {
+        str += '\n' +
+               chalk[errorCount ? 'red' : 'yellow']('>> ') +
+               errorCount + ' failures, ' +
+               warningCount + ' warnings';
+      } else {
+        str += '\n' +
+               chalk.green('>> 0 failures, 0 warnings') +
+               chalk.green('Done, without errors.');
+      }
 
       return str;
     }

--- a/test/fixtures/error.scss
+++ b/test/fixtures/error.scss
@@ -1,0 +1,6 @@
+$black: #000;
+
+.button {
+  display: block;
+  color $black;
+}

--- a/test/fixtures/mixed-issues.scss
+++ b/test/fixtures/mixed-issues.scss
@@ -1,0 +1,4 @@
+.Button {
+  display: block;
+  color black;
+}

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -214,7 +214,7 @@ describe('grunt-scss-lint', function () {
           results = results.split('\n');
 
           expect(results[1]).to.contain(fileFail);
-          expect(results[2]).to.contain('1: [W] SelectorFormat:');
+          expect(results[2]).to.contain('1:\t[W] SelectorFormat:');
           expect(results[1]).not.to.contain(styles.cyan.open + fileFail);
           expect(results[2]).not.to.contain(styles.magenta.open + '1');
           done();

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -388,7 +388,7 @@ describe('grunt-scss-lint', function () {
 
   it('exit code on failure', function (done) {
     spawn({
-      cmd: 'grunt', 
+      cmd: 'grunt',
       args: ['scsslint']
     }, function (error, result, code) {
       expect(code).not.to.be(0);
@@ -416,7 +416,7 @@ describe('grunt-scss-lint', function () {
 
   it('exit code on success', function (done) {
     spawn({
-      cmd: 'grunt', 
+      cmd: 'grunt',
       args: ['scsslint:pass']
     }, function (error, result, code) {
       expect(code).to.be(0);

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -299,7 +299,7 @@ describe('grunt-scss-lint', function () {
           results = results.split('\n');
 
           expect(results[1]).to.contain(fileFail);
-          expect(results[2]).to.contain('1:\t[W] SelectorFormat:');
+          expect(results[2]).to.contain('1: [W] SelectorFormat:');
           expect(results[1]).not.to.contain(styles.cyan.open + fileFail);
           expect(results[2]).not.to.contain(styles.magenta.open + '1');
           done();

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -20,6 +20,8 @@ var _ = require('lodash'),
     reporterOutFile = path.join(process.cwd(), 'scss-lint-report.xml'),
 
     filePass = path.join(fixtures, 'pass.scss'),
+    fileError = path.join(fixtures, 'error.scss'),
+    fileMixedIssues = path.join(fixtures, 'mixed-issues.scss'),
     fileFail = path.join(fixtures, 'fail.scss'),
     fileFail2 = path.join(fixtures, 'fail2.scss');
 
@@ -193,6 +195,89 @@ describe('grunt-scss-lint', function () {
           expect(results).to.contain(styles.magenta.open + '1');
           expect(results).to.contain(styles.yellow.open + '[W]');
           done();
+        });
+      });
+    });
+  });
+
+  describe('Show numbers of issues in a summary line', function () {
+    var scsslint = require('../tasks/lib/scss-lint').init(grunt);
+
+    describe('with colour', function () {
+      ['colouriseOutput', 'colorizeOutput'].forEach(function (task) {
+        var testOptions = _.assign({}, defaultOptions, {
+          compact: true
+        });
+        testOptions[task] = true;
+        it(task + ' only with warnings', function (done) {
+          scsslint.lint(fileFail, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain(chalk.styles.yellow.open + '>>');
+            expect(summaryLine).to.contain('0 failures');
+            expect(summaryLine).to.contain('5 warnings');
+            done();
+          });
+        });
+
+        it(task + ' only with error', function (done) {
+          scsslint.lint(fileError, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain(chalk.styles.red.open + '>>');
+            expect(summaryLine).to.contain('1 failures');
+            expect(summaryLine).to.contain('0 warnings');
+            done();
+          });
+        });
+
+        it(task + ' stops any counting after an error occurs', function (done) {
+          scsslint.lint(fileMixedIssues, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain(chalk.styles.red.open + '>>');
+            expect(summaryLine).to.contain('1 failures');
+            expect(summaryLine).to.contain('0 warnings');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('without colour', function () {
+      ['colouriseOutput', 'colorizeOutput'].forEach(function (task) {
+        var testOptions = _.assign({}, defaultOptions, {
+          compact: true
+        });
+        testOptions[task] = false;
+        it(task + ' only with warnings', function (done) {
+          scsslint.lint(fileFail, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain('>>');
+            expect(summaryLine).not.to.contain(chalk.styles.red.open + '>>');
+            done();
+          });
+        });
+
+        it(task + ' only with error', function (done) {
+          scsslint.lint(fileError, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain('>>');
+            expect(summaryLine).not.to.contain(chalk.styles.red.open + '>>');
+            done();
+          });
+        });
+
+        it(task + ' stops any counting after an error occurs', function (done) {
+          scsslint.lint(fileMixedIssues, testOptions, function (results) {
+            var summaryLine = results.split('\n').pop();
+
+            expect(summaryLine).to.contain('>>');
+            expect(summaryLine).not.to.contain(chalk.styles.yellow.open + '>>');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
Includes:
* show a summary as the last line e.g. `>> 0 failures, 5 warnings`
* uses tabs to list the issues to make the output easier to read if the line numbers are longer
   old

   ```
    1: [W] SelectorFormat:  ...
    12: [W] PropertySortOrder: ...
   ```
   
   new
   ```
    1:	[W] SelectorFormat:  ...
    12:	[W] PropertySortOrder: ...
   ```