### PR TITLE
Use binary checking from Grunt-Contrib-Sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "test": "bundle && grunt test"
   },
   "dependencies": {
+    "chalk": "^1.0.0",
     "lodash": "^3.6.0",
-    "xmlbuilder": "^2.6.2",
-    "chalk": "^1.0.0"
+    "which": "^1.1.1",
+    "xmlbuilder": "^2.6.2"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "0.0.4",

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -1,6 +1,17 @@
 module.exports = function (grunt) {
   var _ = require('lodash'),
-      scsslint = require('./lib/scss-lint').init(grunt);
+      scsslint = require('./lib/scss-lint').init(grunt),
+      which = require('which'),
+      checkBinary = function (cmd, errMsg) {
+        try {
+          which.sync(cmd);
+        } catch (err) {
+          return grunt.warn(
+            '\n' + errMsg + '\n' +
+            'More info: https://github.com/ahmednuaman/grunt-scss-lint\n'
+          );
+        }
+      };
 
   grunt.registerMultiTask('scsslint', 'Validate `.scss` files with `scss-lint`.', function () {
     var done = this.async(),
@@ -21,6 +32,16 @@ module.exports = function (grunt) {
       force: false,
       maxBuffer: 300 * 1024
     });
+
+    if (opts.bundleExec) {
+      checkBinary('bundle',
+        'bundleExec options set but no Bundler executable found in your PATH.'
+      );
+    } else {
+      checkBinary('scss-lint',
+        'You need to have Ruby and sscs_lint installed and in your PATH for this task to work.'
+      );
+    }
 
     grunt.verbose.writeflags(opts, 'scss-lint options');
     grunt.log.writeln('Running scss-lint on ' + target);


### PR DESCRIPTION
Takes the pattern for checking for Bundler and scss_lint from the grunt-contrib-sass method.