### PR TITLE
Adding output of number of files inspected in case of failing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,12 @@ module.exports = function (grunt) {
         },
         src: ['test/fixtures/fail.scss']
       },
+      fileReport: {
+        options: {
+            fileReport: true
+        },
+        src: ['test/fixtures/fail.scss', 'test/fixtures/fail2.scss']
+      },
       exclude: {
         options: {
           exclude: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
       },
       fileReport: {
         options: {
-            fileReport: true
+          fileReport: true
         },
         src: ['test/fixtures/fail.scss', 'test/fixtures/fail2.scss']
       },

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Set `force` to `true` to report scss-lint errors but not fail the task.
 
 Set `maxBuffer` for the `child_process.exec` process, [if you're linting a lot of files and you're recieving no output](https://github.com/ahmednuaman/grunt-scss-lint/issues/63) then you can try and increase this value. Setting it to `false`, `0`, `NaN` or `Infinite` will not return any `stdout` or `stderr` and the task will think that everything's fine.
 
+#### fileReport
+
+- Type: `Boolean`
+- Default: `false`
+
+Prints the number of inspected files in case of failing.
+
 ### Usage Examples
 
 #### Example config

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -212,6 +212,9 @@ exports.init = function (grunt) {
         if (options.force) {
           grunt.log.writeln('scss-lint failed, but was run in force mode');
         }
+        if (options.fileReport) {
+          grunt.log.writeln('scss-lint failed, testing '+fileCount+' files.');
+        }
       }
 
       if (options.reporterOutput) {

--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -213,7 +213,7 @@ exports.init = function (grunt) {
           grunt.log.writeln('scss-lint failed, but was run in force mode');
         }
         if (options.fileReport) {
-          grunt.log.writeln('scss-lint failed, testing '+fileCount+' files.');
+          grunt.log.writeln('scss-lint failed, testing ' + fileCount + ' files.');
         }
       }
 

--- a/tasks/scss-lint.js
+++ b/tasks/scss-lint.js
@@ -30,6 +30,7 @@ module.exports = function (grunt) {
       colorizeOutput: false,
       compact: false,
       force: false,
+      fileReport: false,
       maxBuffer: 300 * 1024
     });
 

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -58,7 +58,6 @@ describe('grunt-scss-lint', function () {
     });
   });
 
-
   it('pass with force', function (done) {
     spawn({
       cmd: 'grunt',
@@ -180,12 +179,12 @@ describe('grunt-scss-lint', function () {
 
   it('Report on number of files', function (done) {
     spawn({
-        cmd: 'grunt',
-        args: ['scsslint:fileReport']
+      cmd: 'grunt',
+      args: ['scsslint:fileReport']
     }, function (error, results, code) {
-        results = results.stdout;
-        expect(results).to.contain('testing 2 files');
-        done();
+      results = results.stdout;
+      expect(results).to.contain('testing 2 files');
+      done();
     });
   });
 

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
     nockExec = require('nock-exec'),
     proxyquire = require('proxyquire'),
     sinon = require('sinon'),
+    util = require('util'),
     
     escapeRe = function (str) {
       return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
@@ -56,6 +57,7 @@ describe('grunt-scss-lint', function () {
       done();
     });
   });
+
 
   it('pass with force', function (done) {
     spawn({
@@ -173,6 +175,17 @@ describe('grunt-scss-lint', function () {
 
       expect(report).to.contain('errors="0"');
       done();
+    });
+  });
+
+  it('Report on number of files', function (done) {
+    spawn({
+        cmd: 'grunt',
+        args: ['scsslint:fileReport']
+    }, function (error, results, code) {
+        results = results.stdout;
+        expect(results).to.contain('testing 2 files');
+        done();
     });
   });
 

--- a/test/scss-lint.spec.js
+++ b/test/scss-lint.spec.js
@@ -36,6 +36,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('fail', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:fail']
@@ -47,6 +48,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('pass', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:pass']
@@ -59,6 +61,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('pass with force', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:force']
@@ -71,6 +74,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('debug option', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:pass', '--debug']
@@ -82,6 +86,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('bundle exec', function (done) {
+    this.timeout(5000);
     var instance = nockExec('bundle exec scss-lint ' + filePass).exit(0),
         scsslint = proxyquire('../tasks/lib/scss-lint', {
           'child_process': nockExec.moduleStub
@@ -98,6 +103,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('config file', function (done) {
+    this.timeout(5000);
     var configFile = path.join(fixtures, '.scss-lint-test.yml'),
         instance = nockExec('scss-lint -c ' + configFile + ' ' + filePass).exit(0),
         scsslint = proxyquire('../tasks/lib/scss-lint', {
@@ -115,6 +121,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('gem version', function (done) {
+    this.timeout(5000);
     var gemVersion = '1.2.3',
         instance = nockExec('scss-lint "_' + gemVersion + '_" ' + filePass).exit(0),
         scsslint = proxyquire('../tasks/lib/scss-lint', {
@@ -132,6 +139,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('pass with excluded file', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:exclude']
@@ -144,6 +152,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('fail with bad options', function (done) {
+    this.timeout(5000);
     var files = '--incorrectlySpecifyingAnOptionAsAFile',
         scsslint = require('../tasks/lib/scss-lint').init(grunt);
 
@@ -154,6 +163,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('reporter with errors', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:fail']
@@ -166,6 +176,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('reporter without errors', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:pass']
@@ -178,6 +189,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('Report on number of files', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:fileReport']
@@ -191,6 +203,7 @@ describe('grunt-scss-lint', function () {
   describe('colourised output', function () {
     ['colouriseOutput', 'colorizeOutput'].forEach(function (task) {
       it(task, function (done) {
+        this.timeout(5000);
         var scsslint = require('../tasks/lib/scss-lint').init(grunt),
             testOptions;
 
@@ -213,6 +226,7 @@ describe('grunt-scss-lint', function () {
   describe('compact without colour', function () {
     ['colouriseOutput', 'colorizeOutput'].forEach(function (task) {
       it(task, function (done) {
+        this.timeout(5000);
         var scsslint = require('../tasks/lib/scss-lint').init(grunt),
             testOptions;
 
@@ -238,6 +252,7 @@ describe('grunt-scss-lint', function () {
   describe('compact with colour', function () {
     ['colouriseOutput', 'colorizeOutput'].forEach(function (task) {
       it(task, function (done) {
+        this.timeout(5000);
         var scsslint = require('../tasks/lib/scss-lint').init(grunt),
             testOptions;
 
@@ -259,6 +274,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('pluralise single file', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:pass']
@@ -269,6 +285,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('pluralise multiple files', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt',
       args: ['scsslint:multiple']
@@ -279,6 +296,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('emit error', function () {
+    this.timeout(5000);
     var eventSpy = sinon.spy(),
         scsslint = require('../tasks/lib/scss-lint').init(grunt),
         testOptions;
@@ -298,6 +316,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('emit success', function () {
+    this.timeout(5000);
     var eventSpy = sinon.spy(),
         scsslint = require('../tasks/lib/scss-lint').init(grunt),
         testOptions;
@@ -314,6 +333,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('exit code on failure', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt', 
       args: ['scsslint']
@@ -324,6 +344,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('exit code and output on missing ruby', function () {
+    this.timeout(5000);
     var nockExec = require('nock-exec'),
         proxyquire = require('proxyquire'),
         scsslint = proxyquire('../tasks/lib/scss-lint', {
@@ -342,6 +363,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('exit code on success', function (done) {
+    this.timeout(5000);
     spawn({
       cmd: 'grunt', 
       args: ['scsslint:pass']
@@ -352,6 +374,7 @@ describe('grunt-scss-lint', function () {
   });
 
   it('max buffer', function () {
+    this.timeout(5000);
     var execSpy = sinon.spy(),
         scsslint = proxyquire('../tasks/lib/scss-lint', {
           'child_process': {


### PR DESCRIPTION
I've needed output of the number of files linted, so I've added fileReport option. if someone is setting it to true, The report will include the numbers of files that were inspected. I've also added test spec for this.