### PR TITLE
Update the install command for scss-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _Run this task with the `grunt scsslint` command._
 
 [scss-lint](https://github.com/causes/scss-lint) is a Ruby gem written by [The Causes Engineering Team](https://github.com/causes), this plugin is simply a grunt wrapper for the gem.
 
-This task requires you to have [Ruby](http://www.ruby-lang.org/en/downloads/), and [scss-lint](https://github.com/causes/scss-lint#installation) installed. If you're on OS X or Linux you probably already have Ruby installed; test with `ruby -v` in your terminal. When you've confirmed you have Ruby installed, run `gem update --system && gem install scss-lint` to install the `scss-lint` gem.
+This task requires you to have [Ruby](http://www.ruby-lang.org/en/downloads/), and [scss-lint](https://github.com/causes/scss-lint#installation) installed. If you're on OS X or Linux you probably already have Ruby installed; test with `ruby -v` in your terminal. When you've confirmed you have Ruby installed, run `gem update --system && gem install scss_lint` to install the `scss-lint` gem.
 
 ### Options
 


### PR DESCRIPTION
Update the scss-lint gem install command, which now has been called `scss_lint` instead of `scss-lint`.

As you can see on the [scss-lint repo](https://github.com/brigade/scss-lint)

![image](https://cloud.githubusercontent.com/assets/1176495/16493314/e43cf7b6-3edc-11e6-8d89-0d912d4aa3b7.png)
