### PR TITLE
bugfixed: windows cmd In Command Prompt, the total length of the foll…

### DIFF
--- a/tasks/lib/scss-lint.js
+++ b/tasks/lib/scss-lint.js
@@ -156,7 +156,7 @@ exports.init = function (grunt) {
 
     if (options.exclude) {
       args.push('-e');
-      args.push(grunt.file.expand(options.exclude).join(','));
+      args.push(options.exclude.join(','));
     }
 
     if (options.require) {


### PR DESCRIPTION
…owing command line that you use at the command prompt cannot contain more than either 2047 or 8191 characters info (https://support.microsoft.com/ru-ru/help/830473/command-prompt-cmd.-exe-command-line-string-limitation)